### PR TITLE
Included the input in the buildRules method

### DIFF
--- a/src/Filter/FilterRules.php
+++ b/src/Filter/FilterRules.php
@@ -12,5 +12,5 @@ interface FilterRules
      * @param Filter $filter
      * @param array $input
      */
-    public function buildRules(Filter $filter, array $input = []);
+    public function buildRules(Filter $filter, array $input);
 }

--- a/src/Filter/FilterRules.php
+++ b/src/Filter/FilterRules.php
@@ -10,6 +10,7 @@ interface FilterRules
 {
     /**
      * @param Filter $filter
+     * @param array $input
      */
-    public function buildRules(Filter $filter);
+    public function buildRules(Filter $filter, array $input = []);
 }

--- a/src/Filter/FilterService.php
+++ b/src/Filter/FilterService.php
@@ -45,7 +45,7 @@ class FilterService
 
         foreach ($filterRulesClasses as $filterRulesClass) {
             $filterRules = $this->filterRulesFactory->make($filterRulesClass);
-            $filterRules->buildRules($filter);
+            $filterRules->buildRules($filter, $input);
         }
 
         return $filter->filter($input);

--- a/src/Validation/ValidationRules.php
+++ b/src/Validation/ValidationRules.php
@@ -14,5 +14,5 @@ interface ValidationRules
      * @param Validator $validator
      * @param array $input
      */
-    public function buildRules(Validator $validator, array $input = []);
+    public function buildRules(Validator $validator, array $input);
 }

--- a/src/Validation/ValidationRules.php
+++ b/src/Validation/ValidationRules.php
@@ -12,6 +12,7 @@ interface ValidationRules
      * Builds the rules for particle/validator.
      *
      * @param Validator $validator
+     * @param array $input
      */
-    public function buildRules(Validator $validator);
+    public function buildRules(Validator $validator, array $input = []);
 }

--- a/src/Validation/ValidationService.php
+++ b/src/Validation/ValidationService.php
@@ -47,7 +47,7 @@ class ValidationService
 
         foreach ($validationRulesClasses as $validationRulesClass) {
             $validationRules = $this->validationRulesFactory->make($validationRulesClass);
-            $validationRules->buildRules($validator);
+            $validationRules->buildRules($validator, $input);
         }
 
         $result = $validator->validate($input);

--- a/tests/Filter/FilterServiceTest.php
+++ b/tests/Filter/FilterServiceTest.php
@@ -8,6 +8,7 @@ use Eloquent\Phony\Phpunit\Phony;
 use Interop\Container\ContainerInterface;
 use Linio\TestAssets\TestFilterRules;
 use Linio\TestAssets\TestFilterRules2;
+use Linio\TestAssets\TestFilterRules3;
 use Particle\Filter\Filter;
 use PHPUnit\Framework\TestCase;
 
@@ -27,5 +28,21 @@ class FilterServiceTest extends TestCase
         $filteredInput = $service->filter($input, $filterRules);
 
         $this->assertSame('testtest2', $filteredInput['key']);
+    }
+
+    public function testItFiltersTheInputValuesInTheRules()
+    {
+        $input = ['key3' => 'part1', 'key4' => 'part2'];
+
+        $container = Phony::mock(ContainerInterface::class);
+
+        $filterClass = Filter::class;
+        $filterFactory = new FilterRulesFactory($container->get());
+        $filterRules = [TestFilterRules3::class];
+
+        $service = new FilterService($filterClass, $filterFactory);
+        $filteredInput = $service->filter($input, $filterRules);
+
+        $this->assertSame('part1part2', $filteredInput['key3']);
     }
 }

--- a/tests/Validation/ValidationServiceTest.php
+++ b/tests/Validation/ValidationServiceTest.php
@@ -9,6 +9,7 @@ use Interop\Container\ContainerInterface;
 use Linio\Common\Expressive\Exception\Http\InvalidRequestException;
 use Linio\TestAssets\TestValidationRules;
 use Linio\TestAssets\TestValidationRules2;
+use Linio\TestAssets\TestValidationRules3;
 use Particle\Validator\ValidationResult;
 use Particle\Validator\Validator;
 use PHPUnit\Framework\TestCase;
@@ -101,5 +102,23 @@ class ValidationServiceTest extends TestCase
 
             throw $exception;
         }
+    }
+
+    public function testItValidatesUsingInputValuesInTheRules()
+    {
+        $input = ['key3' => 'equalValue', 'key4' => 'equalValue'];
+
+        $container = Phony::mock(ContainerInterface::class);
+
+        $validatorFactory = new ValidatorFactory($container->get(), Validator::class);
+
+        $validationRulesFactory = new ValidationRulesFactory($container->get());
+        $validationRules = [TestValidationRules3::class];
+
+        $service = new ValidationService($validatorFactory, $validationRulesFactory);
+
+        $result = $service->validate($input, $validationRules);
+
+        $this->assertNull($result);
     }
 }

--- a/tests/assets/TestFilterRules.php
+++ b/tests/assets/TestFilterRules.php
@@ -13,7 +13,7 @@ class TestFilterRules implements FilterRules
      * @param Filter $filter
      * @param array $input
      */
-    public function buildRules(Filter $filter, array $input = [])
+    public function buildRules(Filter $filter, array $input)
     {
         $filter->value('key')->append('test');
     }

--- a/tests/assets/TestFilterRules2.php
+++ b/tests/assets/TestFilterRules2.php
@@ -11,8 +11,9 @@ class TestFilterRules2 implements FilterRules
 {
     /**
      * @param Filter $filter
+     * @param array $input
      */
-    public function buildRules(Filter $filter)
+    public function buildRules(Filter $filter, array $input = [])
     {
         $filter->value('key')->append('test2');
     }

--- a/tests/assets/TestFilterRules2.php
+++ b/tests/assets/TestFilterRules2.php
@@ -13,7 +13,7 @@ class TestFilterRules2 implements FilterRules
      * @param Filter $filter
      * @param array $input
      */
-    public function buildRules(Filter $filter, array $input = [])
+    public function buildRules(Filter $filter, array $input)
     {
         $filter->value('key')->append('test2');
     }

--- a/tests/assets/TestFilterRules3.php
+++ b/tests/assets/TestFilterRules3.php
@@ -13,7 +13,7 @@ class TestFilterRules3 implements FilterRules
      * @param Filter $filter
      * @param array $input
      */
-    public function buildRules(Filter $filter, array $input = [])
+    public function buildRules(Filter $filter, array $input)
     {
         $filter->value('key3')->append($input['key4']);
     }

--- a/tests/assets/TestFilterRules3.php
+++ b/tests/assets/TestFilterRules3.php
@@ -7,7 +7,7 @@ namespace Linio\TestAssets;
 use Linio\Common\Expressive\Filter\FilterRules;
 use Particle\Filter\Filter;
 
-class TestFilterRules implements FilterRules
+class TestFilterRules3 implements FilterRules
 {
     /**
      * @param Filter $filter
@@ -15,6 +15,6 @@ class TestFilterRules implements FilterRules
      */
     public function buildRules(Filter $filter, array $input = [])
     {
-        $filter->value('key')->append('test');
+        $filter->value('key3')->append($input['key4']);
     }
 }

--- a/tests/assets/TestValidationRules.php
+++ b/tests/assets/TestValidationRules.php
@@ -15,7 +15,7 @@ class TestValidationRules implements ValidationRules
      * @param Validator $validator
      * @param array $input
      */
-    public function buildRules(Validator $validator, array $input = [])
+    public function buildRules(Validator $validator, array $input)
     {
         $validator->required('key');
     }

--- a/tests/assets/TestValidationRules2.php
+++ b/tests/assets/TestValidationRules2.php
@@ -13,8 +13,9 @@ class TestValidationRules2 implements ValidationRules
      * Builds the rules for particle/validator.
      *
      * @param Validator $validator
+     * @param array $input
      */
-    public function buildRules(Validator $validator)
+    public function buildRules(Validator $validator, array $input = [])
     {
         $validator->required('key2');
     }

--- a/tests/assets/TestValidationRules2.php
+++ b/tests/assets/TestValidationRules2.php
@@ -15,7 +15,7 @@ class TestValidationRules2 implements ValidationRules
      * @param Validator $validator
      * @param array $input
      */
-    public function buildRules(Validator $validator, array $input = [])
+    public function buildRules(Validator $validator, array $input)
     {
         $validator->required('key2');
     }

--- a/tests/assets/TestValidationRules3.php
+++ b/tests/assets/TestValidationRules3.php
@@ -15,7 +15,7 @@ class TestValidationRules3 implements ValidationRules
      * @param Validator $validator
      * @param array $input
      */
-    public function buildRules(Validator $validator, array $input = [])
+    public function buildRules(Validator $validator, array $input)
     {
         $validator->required('key3')->equals($input['key4']);
     }

--- a/tests/assets/TestValidationRules3.php
+++ b/tests/assets/TestValidationRules3.php
@@ -7,7 +7,7 @@ namespace Linio\TestAssets;
 use Linio\Common\Expressive\Validation\ValidationRules;
 use Particle\Validator\Validator;
 
-class TestValidationRules implements ValidationRules
+class TestValidationRules3 implements ValidationRules
 {
     /**
      * Builds the rules for particle/validator.
@@ -17,6 +17,6 @@ class TestValidationRules implements ValidationRules
      */
     public function buildRules(Validator $validator, array $input = [])
     {
-        $validator->required('key');
+        $validator->required('key3')->equals($input['key4']);
     }
 }


### PR DESCRIPTION
Included the input in the `buildRules` method so that you can build rules referencing other input variables.
